### PR TITLE
provide better error when key not found

### DIFF
--- a/gpgme.go
+++ b/gpgme.go
@@ -9,6 +9,7 @@ package gpgme
 import "C"
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"runtime"
@@ -389,7 +390,11 @@ func (c *Context) GetKey(fingerprint string, secret bool) (*Key, error) {
 	key := newKey()
 	cfpr := C.CString(fingerprint)
 	defer C.free(unsafe.Pointer(cfpr))
-	return key, handleError(C.gpgme_get_key(c.ctx, cfpr, &key.k, cbool(secret)))
+	err := handleError(C.gpgme_get_key(c.ctx, cfpr, &key.k, cbool(secret)))
+	if key.k == nil {
+		return nil, fmt.Errorf("key %q not found", fingerprint)
+	}
+	return key, err
 }
 
 func (c *Context) Decrypt(ciphertext, plaintext *Data) error {


### PR DESCRIPTION
@mtrmac PTAL

Fix https://github.com/projectatomic/atomic/issues/791

```sh
$ sudo atomic push --sign-by amurdaca@redhat.com docker.io/runcom/busybox:latest
Registry username: runcom
Registry password:
Copying blob sha256:e88b3f82283bc59d5e0df427c824e9f95557e661fcb0ea15fb0fb6f97760f9d9
 1.23 MB / 1.23 MB [===========================================================]
Copying config sha256:e02e811dd08fd49e7f6032625495118e63f597eb150403d02e3238af1df240ba
 0 B / 1.43 KB [---------------------------------------------------------------]
Signing manifest
FATA[0015] Error creating signature: key "amurdaca@redhat.com" not found

```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>