### PR TITLE
support passphrase callback

### DIFF
--- a/go_gpgme.c
+++ b/go_gpgme.c
@@ -1,4 +1,17 @@
 #include "go_gpgme.h"
+#include <errno.h>
+#include <string.h>
+
+gpgme_error_t passphrase_cb (void *opaque, const char *uid_hint, const char *passphrase_info, int last_was_bad, int fd) {
+	(void)uid_hint;
+	(void)passphrase_info;
+	(void)last_was_bad;
+
+	char *pass = (char*) opaque;
+	gpgme_io_writen(fd, pass, strlen(pass));
+	gpgme_io_writen (fd, "\n", 1);
+	return gpgme_error_from_errno (errno);
+}
 
 gpgme_error_t gogpgme_data_new_from_cbs(gpgme_data_t *dh, gpgme_data_cbs_t cbs, uintptr_t handle) {
 	return gpgme_data_new_from_cbs(dh, cbs, (void *)handle);

--- a/go_gpgme.h
+++ b/go_gpgme.h
@@ -11,6 +11,8 @@
 typedef off_t gpgme_off_t; /* Introduced in 1.4.2 */
 #endif
 
+extern gpgme_error_t passphrase_cb (void *opaque, const char *uid_hint, const char *passphrase_info, int last_was_bad, int fd);
+
 extern ssize_t gogpgme_readfunc(void *handle, void *buffer, size_t size);
 extern ssize_t gogpgme_writefunc(void *handle, void *buffer, size_t size);
 extern off_t gogpgme_seekfunc(void *handle, off_t offset, int whence);

--- a/gpgme.go
+++ b/gpgme.go
@@ -14,6 +14,8 @@ import (
 	"runtime"
 	"time"
 	"unsafe"
+
+	"github.com/sirupsen/logrus"
 )
 
 var Version string
@@ -544,6 +546,18 @@ func (c *Context) Encrypt(recipients []*Key, flags EncryptFlag, plaintext, ciphe
 	runtime.KeepAlive(plaintext)
 	runtime.KeepAlive(ciphertext)
 	return handleError(err)
+}
+
+func (c *Context) SetPassphrase(passphrase string) {
+	logrus.Debugf("Setting GPGME passphrase callback", passphrase)
+	callback := C.gpgme_passphrase_cb_t(C.passphrase_cb)
+	cPass := C.CString(passphrase)
+	C.gpgme_set_pinentry_mode(c.ctx, C.GPGME_PINENTRY_MODE_LOOPBACK);
+	C.gpgme_set_passphrase_cb(c.ctx, callback, unsafe.Pointer(cPass))
+}
+
+func (c *Context) ClearPassphrase() {
+	C.gpgme_set_passphrase_cb(c.ctx, nil, nil)
 }
 
 func (c *Context) Sign(signers []*Key, plain, sig *Data, mode SigMode) error {


### PR DESCRIPTION
Add a `SetPassphrase(string)` method to create a passphrase callback
using the specified string as passphrase to prevent gpg from prompting
the user.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>